### PR TITLE
Set a mobile viewport

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -5,6 +5,7 @@
     <title>W3C {{ site.wgname_uc }} Working Group</title>
     <meta http-equiv="X-UA-Compatible" content="chrome=1">
     <meta name="mobile-web-app-capable" content="yes">
+    <meta name="viewport" content="width=device-width">
     <meta name="application-name" content="{{ site.wgname_uc }} Working Group" />
     <meta name="screen-orientation" content="portrait" />
     <meta name="full-screen" content="yes" />


### PR DESCRIPTION
This fixes a rendering issue where font inflation is triggered for a mobile capable website on Firefox for Android. See https://github.com/mozilla-mobile/fenix/issues/13876