### PR TITLE
Creating an onboarding file

### DIFF
--- a/assets/125377
+++ b/assets/125377
@@ -1,0 +1,36 @@
+Welcome to the W3C EPUB 3 Working Group!
+
+We are delighted to have you join us. Our mission is to maintain and develop the EPUB 3 family of specifications, to represent the EPUB community in the W3C, and to support EPUB 3 content creators and consumers by further advancing, refining, and clarifying the current EPUB 3 specification.
+
+Our co-chairs are Dave Cramer (Invited Expert), Shinya Takami (Kadokawa/Bookwalker), and Wendy Reid (Rakuten Kobo). Our staff contact is Ivan Herman.
+
+You will find all information on the Working Group on the Group's home page:
+
+  https://www.w3.org//publishing/groups/epub-wg/
+
+In particular, you can find:
+
+our Work mode: 
+  https://www.w3.org/publishing/groups/epub-wg/WorkMode/
+
+meeting schedules and details:
+  https://www.w3.org/publishing/groups/epub-wg/Meetings/
+
+publication status and milestones:
+  https://www.w3.org/publishing/groups/epub-wg/PublStatus
+
+current participants:
+  https://www.w3.org/groups/wg/epub/participants?sortaff=1
+
+list of the group repositories on github:
+  https://github.com/topics/epub-wg
+
+All participants are required to follow the W3C Code of Ethics and Professional Conduct:
+  https://www.w3.org/Consortium/cepc/
+
+
+Should you have any questions on how to get up to speed with the group, please get in touch with us, e.g., by using the chairs' mailing list:
+  group-epub-wg-chairs@w3.org
+
+Dave, Shinya, Wendy, and Ivan
+


### PR DESCRIPTION
There is a new system at W3C whereby every new participants receives an email message welcoming her/him on the group. By default, a generic message is sent, but we have the possibility to personalize the message for a specific group. The mechanics is to upload, via a PR, a file to https://github.com/w3c/onboarding/tree/master/template. The file's name is the group's W3C ID.

I have created a file in the assets folder on our site. If you agree with the content, I can set it up.