### PR TITLE
Change the charter end date on the home page

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -54,7 +54,7 @@
                     <a href="mailto:wendy.reid@rakuten.com">Wendy Reid</a> (Rakuten Kobo), and 
                     <a href="mailto:takami-s@kadokawa.jp">Shinya Takami</a> (Kadokawa/Bookwalker).
                     The staff contact is <a href="mailto:ivan@w3.org">Ivan Herman</a>.
-                    The group is chartered until 28th of February, 2023.
+                    The group is chartered until 31st of August, 2023.
                 </p>
             </section>
 


### PR DESCRIPTION
To be merged when the charter extension has been announcec to the AC.